### PR TITLE
Adding support for multiple spaces between weekday ranges and hour ranges

### DIFF
--- a/src/get_daily_opening_hours.spec.ts
+++ b/src/get_daily_opening_hours.spec.ts
@@ -21,18 +21,19 @@ import {
 
 describe('getDailyOpeningHours()', () => {
   it.each`
-    input                                | expectedResult
-    ${openOnWeekdays.string}             | ${openOnWeekdays.dailyArray}
-    ${openOnMondaysAndWednesdays.string} | ${openOnMondaysAndWednesdays.dailyArray}
-    ${multipleOpeningIntervals.string}   | ${multipleOpeningIntervals.dailyArray}
-    ${openOnSaturday.string}             | ${openOnSaturday.dailyArray}
-    ${openOnWeekends.string}             | ${openOnWeekends.dailyArray}
-    ${openFridayToTuesday.string}        | ${openFridayToTuesday.dailyArray}
-    ${openNonStop.string}                | ${openNonStop.dailyArray}
-    ${openNonStopOnWeekends.string}      | ${openNonStopOnWeekends.dailyArray}
-    ${unspecifiedClosingTime.string}     | ${unspecifiedClosingTime.dailyArray}
-    ${overrideWithDifferentHours.string} | ${overrideWithDifferentHours.dailyArray}
-    ${overrideWithOff.string}            | ${overrideWithOff.dailyArray}
+    input                                 | expectedResult
+    ${openOnWeekdays.string}              | ${openOnWeekdays.dailyArray}
+    ${openOnMondaysAndWednesdays.string}  | ${openOnMondaysAndWednesdays.dailyArray}
+    ${multipleOpeningIntervals.string}    | ${multipleOpeningIntervals.dailyArray}
+    ${multipleOpeningIntervals.altString} | ${multipleOpeningIntervals.dailyArray}
+    ${openOnSaturday.string}              | ${openOnSaturday.dailyArray}
+    ${openOnWeekends.string}              | ${openOnWeekends.dailyArray}
+    ${openFridayToTuesday.string}         | ${openFridayToTuesday.dailyArray}
+    ${openNonStop.string}                 | ${openNonStop.dailyArray}
+    ${openNonStopOnWeekends.string}       | ${openNonStopOnWeekends.dailyArray}
+    ${unspecifiedClosingTime.string}      | ${unspecifiedClosingTime.dailyArray}
+    ${overrideWithDifferentHours.string}  | ${overrideWithDifferentHours.dailyArray}
+    ${overrideWithOff.string}             | ${overrideWithOff.dailyArray}
   `('returns proper object given $input', ({ input, expectedResult }) => {
     const result = getDailyOpeningHours(input);
 

--- a/src/get_opening_hours.spec.ts
+++ b/src/get_opening_hours.spec.ts
@@ -21,18 +21,19 @@ import {
 
 describe('getOpeningHours()', () => {
   it.each`
-    input                                | expectedResult
-    ${openOnWeekdays.string}             | ${openOnWeekdays.array}
-    ${openOnMondaysAndWednesdays.string} | ${openOnMondaysAndWednesdays.array}
-    ${multipleOpeningIntervals.string}   | ${multipleOpeningIntervals.array}
-    ${openOnSaturday.string}             | ${openOnSaturday.array}
-    ${openOnWeekends.string}             | ${openOnWeekends.array}
-    ${openFridayToTuesday.string}        | ${openFridayToTuesday.array}
-    ${openNonStop.string}                | ${openNonStop.array}
-    ${openNonStopOnWeekends.string}      | ${openNonStopOnWeekends.array}
-    ${unspecifiedClosingTime.string}     | ${unspecifiedClosingTime.array}
-    ${overrideWithDifferentHours.string} | ${overrideWithDifferentHours.array}
-    ${overrideWithOff.string}            | ${overrideWithOff.array}
+    input                                 | expectedResult
+    ${openOnWeekdays.string}              | ${openOnWeekdays.array}
+    ${openOnMondaysAndWednesdays.string}  | ${openOnMondaysAndWednesdays.array}
+    ${multipleOpeningIntervals.string}    | ${multipleOpeningIntervals.array}
+    ${multipleOpeningIntervals.altString} | ${multipleOpeningIntervals.array}
+    ${openOnSaturday.string}              | ${openOnSaturday.array}
+    ${openOnWeekends.string}              | ${openOnWeekends.array}
+    ${openFridayToTuesday.string}         | ${openFridayToTuesday.array}
+    ${openNonStop.string}                 | ${openNonStop.array}
+    ${openNonStopOnWeekends.string}       | ${openNonStopOnWeekends.array}
+    ${unspecifiedClosingTime.string}      | ${unspecifiedClosingTime.array}
+    ${overrideWithDifferentHours.string}  | ${overrideWithDifferentHours.array}
+    ${overrideWithOff.string}             | ${overrideWithOff.array}
   `('returns proper object given $input', ({ input, expectedResult }) => {
     const result = getOpeningHours(input);
 

--- a/src/get_opening_hours.ts
+++ b/src/get_opening_hours.ts
@@ -42,7 +42,7 @@ function getOpeningHours(openingHoursString: string): OpeningHoursArray | null {
   const openingHoursArray: OpeningHoursArray = [];
 
   dayGroups.filter(Boolean).map((dayGroup) => {
-    const [joinedWeekdayRanges, joinedHourRanges] = dayGroup.split(' ') as [
+    const [joinedWeekdayRanges, joinedHourRanges] = dayGroup.split(/\b\s/) as [
       string,
       string | undefined,
     ];
@@ -69,7 +69,7 @@ function getOpeningHours(openingHoursString: string): OpeningHoursArray | null {
         });
       }
 
-      const hourRanges = joinedHourRanges.split(',') as HourRange[];
+      const hourRanges = joinedHourRanges.split(/,\s?/g) as HourRange[];
       const hourGroups = hourRanges.map(toHourGroup).filter(Boolean) as HourGroup[];
 
       openingHoursArray.push({

--- a/src/get_opening_hours.ts
+++ b/src/get_opening_hours.ts
@@ -42,7 +42,7 @@ function getOpeningHours(openingHoursString: string): OpeningHoursArray | null {
   const openingHoursArray: OpeningHoursArray = [];
 
   dayGroups.filter(Boolean).map((dayGroup) => {
-    const [joinedWeekdayRanges, joinedHourRanges] = dayGroup.split(/\b\s/) as [
+    const [joinedWeekdayRanges, joinedHourRanges] = dayGroup.split(/\b\s+/) as [
       string,
       string | undefined,
     ];
@@ -69,7 +69,7 @@ function getOpeningHours(openingHoursString: string): OpeningHoursArray | null {
         });
       }
 
-      const hourRanges = joinedHourRanges.split(/,\s?/g) as HourRange[];
+      const hourRanges = joinedHourRanges.split(/,\s*/) as HourRange[];
       const hourGroups = hourRanges.map(toHourGroup).filter(Boolean) as HourGroup[];
 
       openingHoursArray.push({

--- a/test_data.ts
+++ b/test_data.ts
@@ -39,6 +39,7 @@ export const openOnMondaysAndWednesdays = {
 
 export const multipleOpeningIntervals = {
   string: 'Mo-Fr 08:00-12:00,13:00-17:30',
+  altString: 'Mo-Fr 08:00-12:00, 13:00-17:30',
   array: [
     {
       from: 'Mo',


### PR DESCRIPTION
Hi, thanks for building this package. In playing around with it a little, I noticed it can't find hour breaks if there is a space after the comma, eg `Mo-Fr 10-14, 15-19` vs `Mo-Fr 10-14,15-19`. Several editors automatically add the space, even though the OSM wiki suggests that that is not preferred, so this is a fairly common error.