### PR TITLE
Adding optional Date return to -Next functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ getIsOpenNow('Mo-Fr 08:00-17:30'); // true
 
 #### `getNextClosedAt()`
 
-Gets the next closing time for a given date. Returns null if for a given date place is closed.
+Gets the next closing time for a given date. Returns null if for a given date place is closed. An optional parameter can be used to return a `Date` object instead of a formatted string.
 
 ##### Sample usage
 
@@ -100,11 +100,12 @@ Gets the next closing time for a given date. Returns null if for a given date pl
 import { getNextClosedAt } from '@wojtekmaj/opening-hours-utils';
 
 getNextClosedAt('Mo-Fr 08:00-17:30', mondayNoon); // 'Mo 17:30'
+getNextClosedAt('Mo-Fr 08:00-17:30', mondayNoon, true); // 2022-01-03T17:30:00.000Z
 ```
 
 #### `getNextClosedNow()`
 
-Gets the next closing time. Returns null if place is currently closed.
+Gets the next closing time. Returns null if place is currently closed. An optional parameter can be used to return a `Date` object instead of a formatted string.
 
 ##### Sample usage
 
@@ -112,11 +113,12 @@ Gets the next closing time. Returns null if place is currently closed.
 import { getNextClosedNow } from '@wojtekmaj/opening-hours-utils';
 
 getNextClosedNow('Mo-Fr 08:00-17:30'); // 'Mo 17:30'
+getNextClosedNow('Mo-Fr 08:00-17:30', true); // 2022-01-03T17:30:00.000Z
 ```
 
 #### `getNextOpenAt()`
 
-Gets the next opening time for a given date. Returns null if for a given date place is open.
+Gets the next opening time for a given date. Returns null if for a given date place is open. An optional parameter can be used to return a `Date` object instead of a formatted string.
 
 ##### Sample usage
 
@@ -124,11 +126,12 @@ Gets the next opening time for a given date. Returns null if for a given date pl
 import { getNextOpenAt } from '@wojtekmaj/opening-hours-utils';
 
 getNextOpenAt('Mo-Fr 08:00-17:30', saturdayNoon); // 'Mo 08:00'
+getNextOpenAt('Mo-Fr 08:00-17:30', saturdayNoon, true); // 2022-01-03T08:00:00.000Z
 ```
 
 #### `getNextOpenNow()`
 
-Gets the next opening time. Returns null if place is currently open.
+Gets the next opening time. Returns null if place is currently open. An optional parameter can be used to return a `Date` object instead of a formatted string.
 
 ##### Sample usage
 
@@ -136,6 +139,7 @@ Gets the next opening time. Returns null if place is currently open.
 import { getNextOpenNow } from '@wojtekmaj/opening-hours-utils';
 
 getNextOpenNow('Mo-Fr 08:00-17:30'); // 'Mo 08:00'
+getNextOpenNow('Mo-Fr 08:00-17:30', true); // 2022-01-03T08:00:00.000Z
 ```
 
 #### `getOpeningHours()`

--- a/src/get_next_closed_at.spec.ts
+++ b/src/get_next_closed_at.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import getNextClosedAt from './get_next_closed_at';
 
 import {
+  closeMonday,
   invalidString1,
   invalidString2,
   invalidString3,
@@ -170,6 +171,27 @@ describe('getNextClosedAt()', () => {
       const result = getNextClosedAt(openingHoursString, date);
 
       expect(result).toBe(expectedResult);
+    },
+  );
+
+  it.each`
+    openingHoursString                   | date                  | expectedResult
+    ${openOnWeekdays.string}             | ${mondayMorning}      | ${closeMonday}
+    ${openOnWeekdays.string}             | ${mondayMidday}       | ${closeMonday}
+    ${openOnWeekdays.string}             | ${mondayTwelveThirty} | ${closeMonday}
+    ${openOnMondaysAndWednesdays.string} | ${mondayMorning}      | ${closeMonday}
+    ${openOnMondaysAndWednesdays.string} | ${mondayMidday}       | ${closeMonday}
+    ${openOnMondaysAndWednesdays.string} | ${mondayTwelveThirty} | ${closeMonday}
+    ${openFridayToTuesday.string}        | ${mondayMorning}      | ${closeMonday}
+    ${openFridayToTuesday.string}        | ${mondayMidday}       | ${closeMonday}
+    ${openFridayToTuesday.string}        | ${mondayTwelveThirty} | ${closeMonday}
+    ${openOnMondaysAndWednesdays.string} | ${saturdayEvening}    | ${null}
+  `(
+    'returns $expectedResult given $openingHoursString and $date',
+    ({ openingHoursString, date, expectedResult }) => {
+      const result = getNextClosedAt(openingHoursString, date, true);
+
+      expect(result).toEqual(expectedResult);
     },
   );
 

--- a/src/get_next_closed_at.ts
+++ b/src/get_next_closed_at.ts
@@ -47,10 +47,6 @@ function groupDaysByDaysToClosing(dayGroups: DayGroups, day: Weekday) {
   return groupedDays;
 }
 
-function addMinutes(date: Date, minutes: number) {
-  return new Date(date.getTime() + minutes * 60000);
-}
-
 export function getNextClosedAt(openingHoursString: string, date: Date, returnDate: true): Date;
 export function getNextClosedAt(
   openingHoursString: string,

--- a/src/get_next_closed_at.ts
+++ b/src/get_next_closed_at.ts
@@ -2,6 +2,7 @@ import getDailyOpeningHours from './get_daily_opening_hours';
 import getIsOpenAt from './get_is_open_at';
 
 import {
+  addMinutes,
   getDayDiff,
   getHourGroups,
   getMinutesFromMidnightFromDate,
@@ -50,7 +51,17 @@ function addMinutes(date: Date, minutes: number) {
   return new Date(date.getTime() + minutes * 60000);
 }
 
-export default function getNextClosedAt(openingHoursString: string, date: Date): string | null {
+export function getNextClosedAt(openingHoursString: string, date: Date, returnDate: true): Date;
+export function getNextClosedAt(
+  openingHoursString: string,
+  date: Date,
+  returnDate: false,
+): string | null;
+export default function getNextClosedAt(
+  openingHoursString: string,
+  date: Date,
+  returnDate = false,
+): Date | string | null {
   if (typeof openingHoursString === 'undefined' || openingHoursString === null) {
     throw new Error('openingHoursString is required');
   }
@@ -118,6 +129,9 @@ export default function getNextClosedAt(openingHoursString: string, date: Date):
           continue;
         }
 
+        if (returnDate) {
+          return closingTime;
+        }
         return `${getWeekdayName(dayGroupDay)} ${hourGroup.to}`;
       }
     }

--- a/src/get_next_closed_now.ts
+++ b/src/get_next_closed_now.ts
@@ -1,5 +1,10 @@
 import getNextClosedAt from './get_next_closed_at';
 
-export default function getNextClosedNow(openingHoursString: string): string | null {
-  return getNextClosedAt(openingHoursString, new Date());
+export function getNextClosedNow(openingHoursString: string, returnDate: true): Date;
+export function getNextClosedNow(openingHoursString: string, returnDate: false): string | null;
+export default function getNextClosedNow(
+  openingHoursString: string,
+  returnDate = false,
+): Date | string | null {
+  return getNextClosedAt(openingHoursString, new Date(), returnDate);
 }

--- a/src/get_next_open_at.spec.ts
+++ b/src/get_next_open_at.spec.ts
@@ -12,6 +12,7 @@ import {
   mondayMorning,
   mondayTwelveThirty,
   multipleOpeningIntervals,
+  openMonday,
   openFridayToTuesday,
   openNonStop,
   openNonStopOnWeekends,
@@ -169,6 +170,66 @@ describe('getNextOpenAt()', () => {
       const result = getNextOpenAt(openingHoursString, date);
 
       expect(result).toBe(expectedResult);
+    },
+  );
+
+  it.each`
+    openingHoursString                   | date                  | expectedResult
+    ${openOnWeekdays.string}             | ${saturdayMidnight}   | ${openMonday}
+    ${openOnWeekdays.string}             | ${saturdayEightAm}    | ${openMonday}
+    ${openOnWeekdays.string}             | ${saturdayMidday}     | ${openMonday}
+    ${openOnWeekdays.string}             | ${saturdayEvening}    | ${openMonday}
+    ${openOnWeekdays.string}             | ${mondayMidnight}     | ${openMonday}
+    ${openOnWeekdays.string}             | ${mondayMorning}      | ${null}
+    ${openOnWeekdays.string}             | ${mondayMidday}       | ${null}
+    ${openOnWeekdays.string}             | ${mondayTwelveThirty} | ${null}
+    ${openOnMondaysAndWednesdays.string} | ${saturdayMidnight}   | ${openMonday}
+    ${openOnMondaysAndWednesdays.string} | ${saturdayEightAm}    | ${openMonday}
+    ${openOnMondaysAndWednesdays.string} | ${saturdayMidday}     | ${openMonday}
+    ${openOnMondaysAndWednesdays.string} | ${saturdayEvening}    | ${openMonday}
+    ${openOnMondaysAndWednesdays.string} | ${mondayMidnight}     | ${openMonday}
+    ${openOnMondaysAndWednesdays.string} | ${mondayMorning}      | ${null}
+    ${openOnMondaysAndWednesdays.string} | ${mondayMidday}       | ${null}
+    ${openOnMondaysAndWednesdays.string} | ${mondayTwelveThirty} | ${null}
+    ${multipleOpeningIntervals.string}   | ${saturdayMidnight}   | ${openMonday}
+    ${multipleOpeningIntervals.string}   | ${saturdayEightAm}    | ${openMonday}
+    ${multipleOpeningIntervals.string}   | ${saturdayMidday}     | ${openMonday}
+    ${multipleOpeningIntervals.string}   | ${saturdayEvening}    | ${openMonday}
+    ${multipleOpeningIntervals.string}   | ${mondayMidnight}     | ${openMonday}
+    ${multipleOpeningIntervals.string}   | ${mondayMorning}      | ${null}
+    ${multipleOpeningIntervals.string}   | ${mondayMidday}       | ${null}
+    ${openFridayToTuesday.string}        | ${mondayMidnight}     | ${openMonday}
+    ${openFridayToTuesday.string}        | ${mondayMorning}      | ${null}
+    ${openFridayToTuesday.string}        | ${mondayMidday}       | ${null}
+    ${openFridayToTuesday.string}        | ${mondayTwelveThirty} | ${null}
+    ${openNonStop.string}                | ${saturdayMidnight}   | ${null}
+    ${openNonStop.string}                | ${saturdayEightAm}    | ${null}
+    ${openNonStop.string}                | ${saturdayMidday}     | ${null}
+    ${openNonStop.string}                | ${saturdayEvening}    | ${null}
+    ${openNonStop.string}                | ${mondayMidnight}     | ${null}
+    ${openNonStop.string}                | ${mondayMorning}      | ${null}
+    ${openNonStop.string}                | ${mondayMidday}       | ${null}
+    ${openNonStop.string}                | ${mondayTwelveThirty} | ${null}
+    ${openNonStop.string}                | ${mondayEvening}      | ${null}
+    ${openNonStopOnWeekends.string}      | ${saturdayMidnight}   | ${null}
+    ${openNonStopOnWeekends.string}      | ${saturdayEightAm}    | ${null}
+    ${openNonStopOnWeekends.string}      | ${saturdayMidday}     | ${null}
+    ${openNonStopOnWeekends.string}      | ${saturdayEvening}    | ${null}
+    ${unspecifiedClosingTime.string}     | ${saturdayMidday}     | ${null}
+    ${unspecifiedClosingTime.string}     | ${saturdayEvening}    | ${null}
+    ${overrideWithDifferentHours.string} | ${saturdayMidday}     | ${null}
+    ${overrideWithDifferentHours.string} | ${saturdayEvening}    | ${null}
+    ${overrideWithDifferentHours.string} | ${mondayMidday}       | ${null}
+    ${overrideWithDifferentHours.string} | ${mondayTwelveThirty} | ${null}
+    ${overrideWithDifferentHours.string} | ${mondayEvening}      | ${null}
+    ${overrideWithOff.string}            | ${saturdayMidday}     | ${null}
+    ${overrideWithOff.string}            | ${saturdayEvening}    | ${null}
+  `(
+    'returns $expectedResult given $openingHoursString and $date',
+    ({ openingHoursString, date, expectedResult }) => {
+      const result = getNextOpenAt(openingHoursString, date, true);
+
+      expect(result).toEqual(expectedResult);
     },
   );
 

--- a/src/get_next_open_now.ts
+++ b/src/get_next_open_now.ts
@@ -1,5 +1,10 @@
 import getNextOpenAt from './get_next_open_at';
 
-export default function getNextOpenNow(openingHoursString: string): string | null {
-  return getNextOpenAt(openingHoursString, new Date());
+export function getNextOpenNow(openingHoursString: string, returnDate: true): Date;
+export function getNextOpenNow(openingHoursString: string, returnDate: false): string | null;
+export default function getNextOpenNow(
+  openingHoursString: string,
+  returnDate = false,
+): Date | string | null {
+  return getNextOpenAt(openingHoursString, new Date(), returnDate);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,3 +54,7 @@ export function isValidHour(hour: unknown): hour is Hour {
 export function isValidWeekdayName(weekday: unknown): weekday is WeekdayName {
   return Object.values(WEEKDAY_NAMES).includes(weekday as WeekdayName);
 }
+
+export function addMinutes(date: Date, minutes: number) {
+  return new Date(date.getTime() + minutes * 60000);
+}

--- a/test_data.ts
+++ b/test_data.ts
@@ -342,6 +342,8 @@ export const saturdayEightAm = new Date(2022, 0, 1, 8);
 export const saturdayMidday = new Date(2022, 0, 1, 12);
 export const saturdayEvening = new Date(2022, 0, 1, 18);
 
+export const closeMonday = new Date(2022, 0, 3, 17, 30);
+export const openMonday = new Date(2022, 0, 3, 8);
 export const mondayMidnight = new Date(2022, 0, 3);
 export const mondayMorning = new Date(2022, 0, 3, 8);
 export const mondayMidday = new Date(2022, 0, 3, 12);


### PR DESCRIPTION
Ok, one more PR to add a function that I think would make this project very useful: an option to allow the `getNextClosedAt` and `getNextOpenAt` functions (and their `~Now` companions) to return `Date` objects. I've updated the corresponding tests and documentation as well.